### PR TITLE
Fixes Angel's Petrochem Compatibility

### DIFF
--- a/compatibility-scripts/data-final-fixes/angels/angelspetrochem.lua
+++ b/compatibility-scripts/data-final-fixes/angels/angelspetrochem.lua
@@ -63,13 +63,24 @@ if mods["angelspetrochem"] then
     )
   end
 
-  -- Remove other unseful recipes and techs
-  data.raw.technology["resin-1"] = nil
-  data.raw.technology["resin-2"] = nil
-  data.raw.technology["resin-3"] = nil
+  -- Disable technologies 
+  local to_disable = {
+    "resin-1",
+    "resin-2",
+    "resin-3",
+    "angels-flare-stack",
+    "rubber"
+  }
+  
+  for _, research_name in pairs(to_disable) do
+    if data.raw.technology[research_name] then
+        data.raw.technology[research_name].enabled = false        
+    end
+  end
 
-  data.raw.technology["angel-flare-stack"] = nil
-  data.raw.technology["rubber"] = nil
+--Fix Technology Dead end
+krastorio.technologies.removeResearchUnitIngredient("rocket-fuel", "utility-science-pack")
+krastorio.technologies.addPrerequisite("rocket-fuel","production-science-pack")
 
   -- Change the air filters
   krastorio.technologies.addPrerequisite("kr-advanced-chemistry", "angels-nitrogen-processing-1")


### PR DESCRIPTION
Disables resin-{n}, angels-flare-stack, & rubber technologies instead of setting them to nil. Startup seemingly one or more of those recipes were referenced later causing a crash.

Removes utility-science-packs from the research for rocket fuel when angel's petro is in. This otherwise causes a research dead end that is a loop. Without this: Rocket fuel needs utility science packs to research, and utility science packs need rocket fuel to craft.